### PR TITLE
Switch over to 32blit-sdk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,25 +25,25 @@ jobs:
           - os: ubuntu-20.04
             name: Linux
             release-suffix: LIN64
-            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit
+            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk
             apt-packages: libsdl2-dev libsdl2-image-dev libsdl2-net-dev python3-setuptools
 
           - os: ubuntu-20.04
             name: STM32
             release-suffix: STM32
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit/32blit.toolchain
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit-sdk/32blit.toolchain
             apt-packages: gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
 
           - os: macos-latest
             name: macOS
             release-suffix: MACOS
-            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit
+            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk
             brew-packages: sdl2 sdl2_image sdl2_net
 
           - os: windows-latest
             name: Visual Studio
             release-suffix: WIN64
-            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit -DSDL2_DIR=$GITHUB_WORKSPACE/32blit/vs/sdl
+            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk -DSDL2_DIR=$GITHUB_WORKSPACE/32blit-sdk/vs/sdl
 
     runs-on: ${{matrix.os}}
 
@@ -62,7 +62,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: 32blit/32blit-sdk
-        path: 32blit
+        path: 32blit-sdk
 
     # Linux dependencies
     - name: Install Linux deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           - os: ubuntu-20.04
             name: Linux
             release-suffix: LIN64
-            cmake-args: -D32BLIT_PATH=$GITHUB_WORKSPACE/32blit
+            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit
             apt-packages: libsdl2-dev libsdl2-image-dev libsdl2-net-dev python3-setuptools
 
           - os: ubuntu-20.04
@@ -37,13 +37,13 @@ jobs:
           - os: macos-latest
             name: macOS
             release-suffix: MACOS
-            cmake-args: -D32BLIT_PATH=$GITHUB_WORKSPACE/32blit
+            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit
             brew-packages: sdl2 sdl2_image sdl2_net
 
           - os: windows-latest
             name: Visual Studio
             release-suffix: WIN64
-            cmake-args: -D32BLIT_PATH=$GITHUB_WORKSPACE/32blit -DSDL2_DIR=$GITHUB_WORKSPACE/32blit/vs/sdl
+            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit -DSDL2_DIR=$GITHUB_WORKSPACE/32blit/vs/sdl
 
     runs-on: ${{matrix.os}}
 
@@ -61,7 +61,7 @@ jobs:
     - name: Checkout 32Blit API
       uses: actions/checkout@v2
       with:
-        repository: pimoroni/32blit-beta
+        repository: 32blit/32blit-sdk
         path: 32blit
 
     # Linux dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 cmake_minimum_required(VERSION 3.8)
 
 project(rocks-and-diamonds)
-set(32BLIT_PATH "../" CACHE PATH "Path to 32blit.cmake")
 set(PROJECT_SOURCE rocks-and-diamonds.cpp rocks-and-diamonds.hpp)
 set(PROJECT_DISTRIBS LICENSE README.md)
 
@@ -12,10 +11,7 @@ if(MSVC)
 else()
   add_compile_options("-Wall" "-Wextra" "-Wdouble-promotion")
 endif()
-if(NOT EXISTS ${32BLIT_PATH}/32blit.cmake)
-  message(FATAL_ERROR "Define location of 32Blit API with -D32BLIT_PATH=<path to 32blit.cmake>")
-endif()
-include (${32BLIT_PATH}/32blit.cmake)
+find_package(32BLIT CONFIG REQUIRED PATHS ../ /opt)
 
 blit_executable (${PROJECT_NAME} ${PROJECT_SOURCE})
 blit_assets_yaml (${PROJECT_NAME} assets.yml)


### PR DESCRIPTION
Switches to the new home of the GitHub repository and updates CMakeLists.txt to use the `find_package` approach.