### PR TITLE
Remove tmx struct declaration

### DIFF
--- a/rocks-and-diamonds.cpp
+++ b/rocks-and-diamonds.cpp
@@ -33,17 +33,6 @@ struct Feedback {
   bool rock_thunk;
 };
 
-#pragma pack(push,1)
-struct TMX {
-  char head[4];
-  uint8_t empty_tile;
-  uint16_t width;
-  uint16_t height;
-  uint16_t layers;
-  uint8_t data[];
-};
-#pragma pack(pop)
-
 struct Player {
   Point start;
   Point position;

--- a/rocks-and-diamonds.hpp
+++ b/rocks-and-diamonds.hpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <stdint.h>
 
 #include "32blit.hpp"


### PR DESCRIPTION
Removes the tmx struct because it is already defined in the 32blit namespace.