### PR TITLE
Un-break 32blit builds without 32BLIT_DIR set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           - os: ubuntu-20.04
             name: STM32
             release-suffix: STM32
-            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit-sdk/32blit.toolchain
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit-sdk/32blit.toolchain
             apt-packages: gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
 
           - os: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
             name: PicoSystem
             cache-key: picosystem
             release-suffix: PicoSystem
-            cmake-args: -D32BLIT_DIR=$GITHUB_WORKSPACE/32blit-sdk -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DPICO_BOARD=pimoroni_picosystem
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/32blit-sdk/pico.toolchain -DPICO_BOARD=pimoroni_picosystem
             apt-packages: gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3-setuptools
 
           - os: ubuntu-20.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 # Wrapper for the Pico SDK, which is only included if PICO_BOARD is set
-include(${32BLIT_DIR}/32blit-pico/sdk_import.cmake)
+include(${32BLIT_DIR}/32blit-pico/sdk_import.cmake OPTIONAL)
 
 project(rocks-and-diamonds)
 set(PROJECT_SOURCE rocks-and-diamonds.cpp rocks-and-diamonds.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Basic parameters; check that these match your project / environment
 cmake_minimum_required(VERSION 3.8)
 
-# Wrapper for the Pico SDK, which is only included if PICO_BOARD is set
-include(${32BLIT_DIR}/32blit-pico/sdk_import.cmake OPTIONAL)
-
 project(rocks-and-diamonds)
 set(PROJECT_SOURCE rocks-and-diamonds.cpp rocks-and-diamonds.hpp)
 set(PROJECT_DISTRIBS LICENSE README.md)


### PR DESCRIPTION
... and don't set 32BLIT_DIR for STM32 actions builds.
I'm too lazy to type out both setting the toolchain and the SDK dir...

(Also this is how the boilerplate and the "build all the things" script... build things)